### PR TITLE
OOM fix: eval max batch size and NN to cpu

### DIFF
--- a/experiments/dataset.py
+++ b/experiments/dataset.py
@@ -2,6 +2,7 @@
 import os
 import pickle
 from ast import List
+import math
 
 import numpy as np
 import torch
@@ -113,8 +114,16 @@ def get_dataset_subset(
         data = get_cifar10_data(dataset, index[:1], index)
         input_list = []
         targets_list = []
+
+        MAX_BATCH_SIZE = 5000 # to avoid OOM
+        size = len(index)
+        list_divisors = list(set(
+            factor for i in range(1, int(math.sqrt(size)) + 1) if size % i == 0 for factor in (i, size // i) if
+            factor < MAX_BATCH_SIZE))
+        batch_size = max(list_divisors)
+
         for inputs, targets in get_batches(
-            data, key="eval", batchsize=2500, shuffle=False
+                data, key="eval", batchsize=batch_size, shuffle=False
         ):
             input_list.append(inputs)
             targets_list.append(targets)

--- a/experiments/fast_train.py
+++ b/experiments/fast_train.py
@@ -866,6 +866,7 @@ def fast_train_fun(data, net, hyp=hyp, batchsize=batchsize, eval_batchsize = 250
                 ),
                 is_final_entry=(epoch >= math.ceil(hyp["misc"]["train_epochs"] - 1)),
             )
+    net_ema.to("cpu") 
     return net_ema, train_acc, train_loss, ema_val_acc, val_loss
 
 


### PR DESCRIPTION
1. Change hardcoded eval batch size if the test size isn't divisible by 1000. 
2. Neural Networks are put to the cpu after training to avoid OOM when computing rescaled logits.